### PR TITLE
Fixes kubectl command to get svc instead of pod

### DIFF
--- a/content/beginner/130_exposing-service/accessing.md
+++ b/content/beginner/130_exposing-service/accessing.md
@@ -91,7 +91,7 @@ Kubernetes offers a DNS cluster add-on Service that automatically assigns dns na
 To check if your cluster is already running CoreDNS, use the following command.
 
 ```bash
-kubectl get pod -n kube-system -l k8s-app=kube-dns
+kubectl get svc -n kube-system -l k8s-app=kube-dns
 ```
 
 {{% notice note %}}


### PR DESCRIPTION
A `kubectl` command is getting the pods, but by the output and the description shown it looks the intended command was to get the services.
